### PR TITLE
Add vertical spacing when wrapped

### DIFF
--- a/lib/models/chip_config.dart
+++ b/lib/models/chip_config.dart
@@ -49,6 +49,7 @@ class ChipConfig {
 
   final double radius;
   final double spacing;
+  final double runSpacing;
 
   final Widget? separator;
 
@@ -63,6 +64,7 @@ class ChipConfig {
     this.padding = const EdgeInsets.only(left: 12, top: 0, right: 4, bottom: 0),
     this.radius = 18,
     this.spacing = 8,
+    this.runSpacing = 8,
     this.separator,
     this.labelColor = Colors.white,
     this.labelStyle,

--- a/lib/multiselect_dropdown.dart
+++ b/lib/multiselect_dropdown.dart
@@ -391,7 +391,7 @@ class _MultiSelectDropDownState extends State<MultiSelectDropDown> {
             ),
             padding: const EdgeInsets.symmetric(
               horizontal: 8,
-              vertical: 4,
+              vertical: 8,
             ),
             decoration: _getContainerDecoration(),
             child: Row(
@@ -470,6 +470,7 @@ class _MultiSelectDropDownState extends State<MultiSelectDropDown> {
     }
     return Wrap(
         spacing: widget.chipConfig.spacing,
+        runSpacing: widget.chipConfig.runSpacing,
         children: mapIndexed(_selectedOptions, (index, item) {
           if (widget.selectedItemBuilder != null) {
             return widget.selectedItemBuilder!(


### PR DESCRIPTION
Hi Narendra Bhatt,

I was using your package and I like it a lot, thank you for making it. I only had one problem with it: Once the items get wrapped, they seem to be too close vertically from one another (see below). It doesn't look as good – by adding some padding, it looks more evenly distributed, resulting in a better look.

Let me know what you think, I would love to use your package in my project(s). Thanks.

### This is what it looks like without wrapping:
![normal](https://user-images.githubusercontent.com/111225446/193246201-e3e35c86-0d2f-4099-b4b1-58f5f6e9bd8a.png)

### Wrapping before:
![oldWrap](https://user-images.githubusercontent.com/111225446/193246206-56838862-ae36-48a6-9969-a3a55d7a2605.png)

### Wrapping after adding the vertical padding:
![newWrap](https://user-images.githubusercontent.com/111225446/193246208-5b7d5744-8a64-4f2b-84b0-13cd587d78a3.png)

There are 2 things I have done:

1. _Padding between the Chips:_ I added a `runSpacing` property (like the existing `spacing` property) and used in the Wrap widget
2. _Padding between the Chips and the top and bottom of the whole button:_ I changed the `vertical` spacing from 4 to 8, just like the `horizontal` spacing