### PR TITLE
Added an option to add apply required border-radius.

### DIFF
--- a/lib/multiselect_dropdown.dart
+++ b/lib/multiselect_dropdown.dart
@@ -61,6 +61,7 @@ class MultiSelectDropDown extends StatefulWidget {
   final IconData? suffixIcon;
   final Decoration? inputDecoration;
   final double? borderRadius;
+  final BorderRadiusGeometry? radiusGeometry;
   final Color? borderColor;
   final double? borderWidth;
   final EdgeInsets? padding;
@@ -204,6 +205,7 @@ class MultiSelectDropDown extends StatefulWidget {
     this.borderColor = Colors.grey,
     this.borderWidth = 0.4,
     this.borderRadius = 12.0,
+    this.radiusGeometry,
   })  : networkConfig = null,
         responseParser = null,
         responseErrorBuilder = null,
@@ -249,6 +251,7 @@ class MultiSelectDropDown extends StatefulWidget {
     this.borderColor = Colors.grey,
     this.borderWidth = 0.4,
     this.borderRadius = 12.0,
+    this.radiusGeometry,
   })  : options = const [],
         super(key: key);
 
@@ -417,7 +420,9 @@ class _MultiSelectDropDownState extends State<MultiSelectDropDown> {
     return widget.inputDecoration ??
         BoxDecoration(
           color: widget.backgroundColor ?? Colors.white,
-          borderRadius: BorderRadius.circular(widget.borderRadius ?? 12.0),
+          borderRadius: widget.radiusGeometry != null
+              ? BorderRadius.circular(widget.borderRadius ?? 12.0)
+              : widget.radiusGeometry,
           border: Border.all(
             color: widget.borderColor ?? Colors.grey,
             width: widget.borderWidth ?? 0.4,

--- a/lib/multiselect_dropdown.dart
+++ b/lib/multiselect_dropdown.dart
@@ -420,9 +420,8 @@ class _MultiSelectDropDownState extends State<MultiSelectDropDown> {
     return widget.inputDecoration ??
         BoxDecoration(
           color: widget.backgroundColor ?? Colors.white,
-          borderRadius: widget.radiusGeometry != null
-              ? BorderRadius.circular(widget.borderRadius ?? 12.0)
-              : widget.radiusGeometry,
+          borderRadius: widget.radiusGeometry ??
+              BorderRadius.circular(widget.borderRadius ?? 12.0),
           border: Border.all(
             color: widget.borderColor ?? Colors.grey,
             width: widget.borderWidth ?? 0.4,


### PR DESCRIPTION
- Previously users were allowed to pass only double value as a radius which is applied to the overall radius of the widget. Now they can also pass RadiusGeometry.