### PR TITLE
fix: onOptionRemoved called when unselected from options list

### DIFF
--- a/lib/multiselect_dropdown.dart
+++ b/lib/multiselect_dropdown.dart
@@ -858,6 +858,8 @@ class _MultiSelectDropDownState<T> extends State<MultiSelectDropDown<T>> {
                                     setState(() {
                                       _selectedOptions.remove(option);
                                     });
+                                    widget.onOptionRemoved?.call(index, option);
+                                    _controller.clearSelection(option);
                                   } else {
                                     final bool hasReachMax =
                                         widget.maxItems == null


### PR DESCRIPTION
onOptionRemoved is not triggered incase the option is unselected from the list/dropdown. This change will allow the same.