### PR TITLE
Expose on search change

### DIFF
--- a/lib/src/controllers/multiselect_controller.dart
+++ b/lib/src/controllers/multiselect_controller.dart
@@ -36,6 +36,9 @@ class MultiSelectController<T> extends ChangeNotifier {
   /// on selection changed callback invoker.
   OnSelectionChanged<T>? _onSelectionChanged;
 
+  /// on search changed callback invoker.
+  OnSearchChanged? _onSearchChanged;
+
   /// sets the list of dropdown items.
   /// It replaces the existing list of dropdown items.
   void setItems(List<DropdownItem<T>> options) {
@@ -201,6 +204,11 @@ class MultiSelectController<T> extends ChangeNotifier {
   // ignore: use_setters_to_change_properties
   void _setOnSelectionChange(OnSelectionChanged<T>? onSelectionChanged) {
     this._onSelectionChanged = onSelectionChanged;
+  }
+
+  // ignore: use_setters_to_change_properties
+  void _setOnSearchChange(OnSearchChanged? onSearchChanged) {
+    this._onSearchChanged = onSearchChanged;
   }
 
   // sets the search query.

--- a/lib/src/controllers/multiselect_controller.dart
+++ b/lib/src/controllers/multiselect_controller.dart
@@ -225,6 +225,7 @@ class MultiSelectController<T> extends ChangeNotifier {
           )
           .toList();
     }
+    _onSearchChanged?.call(query);
     notifyListeners();
   }
 

--- a/lib/src/multi_dropdown.dart
+++ b/lib/src/multi_dropdown.dart
@@ -24,6 +24,9 @@ typedef DropdownItemBuilder<T> = Widget Function(
 /// typedef for the callback when the item is selected/de-selected/disabled.
 typedef OnSelectionChanged<T> = void Function(List<T> selectedItems);
 
+/// typedef for the callback when the search field value changes.
+typedef OnSearchChanged = ValueChanged<String>;
+
 /// typedef for the selected item builder.
 typedef SelectedItemBuilder<T> = Widget Function(DropdownItem<T> item);
 

--- a/lib/src/multi_dropdown.dart
+++ b/lib/src/multi_dropdown.dart
@@ -267,7 +267,8 @@ class _MultiDropdownState<T extends Object> extends State<MultiDropdown<T>> {
     _dropdownController
       ..setItems(widget.items)
       ..addListener(_controllerListener)
-      .._setOnSelectionChange(widget.onSelectionChange);
+      .._setOnSelectionChange(widget.onSelectionChange)
+      .._setOnSearchChange(widget.onSearchChange);
 
     // if close on back button is enabled, then add the listener
     _listenBackButton();

--- a/lib/src/multi_dropdown.dart
+++ b/lib/src/multi_dropdown.dart
@@ -104,6 +104,7 @@ class MultiDropdown<T extends Object> extends StatefulWidget {
     this.selectedItemBuilder,
     this.focusNode,
     this.onSelectionChange,
+    this.onSearchChange,
     this.closeOnBackButton = false,
     Key? key,
   })  : future = null,
@@ -151,6 +152,7 @@ class MultiDropdown<T extends Object> extends StatefulWidget {
     this.selectedItemBuilder,
     this.focusNode,
     this.onSelectionChange,
+    this.onSearchChange,
     this.closeOnBackButton = false,
     Key? key,
   })  : items = const [],
@@ -214,6 +216,9 @@ class MultiDropdown<T extends Object> extends StatefulWidget {
   ///
   /// This callback is called when any item is selected or unselected.
   final OnSelectionChanged<T>? onSelectionChange;
+
+  /// The callback when the search field value changes.
+  final OnSearchChanged? onSearchChange;
 
   /// Whether to close the dropdown when the back button is pressed.
   ///


### PR DESCRIPTION
This PR exposes the on search change callback, so that users of MultiDropdown can listen to changes in the search text field:

```
return MultiDropdown.future(
  onSearchChange: (final value) {
    debugPrint('**** search changed: $value');
  },
}
```