### PR TITLE
zOrderIndex!=null error fix

### DIFF
--- a/lib/src/multi_dropdown.dart
+++ b/lib/src/multi_dropdown.dart
@@ -318,7 +318,7 @@ class _MultiDropdownState<T extends Object> extends State<MultiDropdown<T>> {
       _portalController.show();
     } else {
       _dropdownController._clearSearchQuery();
-      _portalController.hide();
+      // _portalController.hide();
     }
   }
 
@@ -653,6 +653,7 @@ class _MultiDropdownState<T extends Object> extends State<MultiDropdown<T>> {
     if (!_dropdownController.isOpen) return;
 
     _dropdownController.closeDropdown();
+    _portalController.hide();
   }
 
   void _showError(String message) {


### PR DESCRIPTION
- error dosent happen if the `_portalController.hide()` is moved into `_handleOutsideTap `