### PR TITLE
feat: ✨ Added platform helper

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -158,7 +158,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.0.0"
+    version: "3.0.0-beta.1"
   path:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -158,7 +158,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.0.0-beta.1"
+    version: "3.0.0"
   path:
     dependency: transitive
     description:

--- a/lib/src/multi_dropdown.dart
+++ b/lib/src/multi_dropdown.dart
@@ -1,10 +1,11 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io' if (dart.library.io) 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+
+import 'package:multi_dropdown/src/platform_helper/platform_helper.dart';
 
 part 'controllers/future_controller.dart';
 part 'controllers/multiselect_controller.dart';

--- a/lib/src/platform_helper/_browser_platform_helper.dart
+++ b/lib/src/platform_helper/_browser_platform_helper.dart
@@ -1,0 +1,6 @@
+import 'package:flutter/foundation.dart';
+
+///The capability of a Operative System to have shortcuts.
+bool get operatingSystemShortcutAvailable {
+  return kIsWeb;
+}

--- a/lib/src/platform_helper/_elsewhere_platform_helper.dart
+++ b/lib/src/platform_helper/_elsewhere_platform_helper.dart
@@ -1,0 +1,6 @@
+import 'dart:io';
+
+///The capability of a Operative System to have shortcuts.
+bool get operatingSystemShortcutAvailable {
+  return Platform.isMacOS || Platform.isLinux || Platform.isWindows;
+}

--- a/lib/src/platform_helper/platform_helper.dart
+++ b/lib/src/platform_helper/platform_helper.dart
@@ -1,0 +1,2 @@
+export '_browser_platform_helper.dart'
+    if (dart.library.io) '_elsewhere_platform_helper.dart';

--- a/lib/src/widgets/dropdown.dart
+++ b/lib/src/widgets/dropdown.dart
@@ -126,7 +126,7 @@ class _Dropdown<T> extends StatelessWidget {
       ),
     );
 
-    if (kIsWeb || Platform.isMacOS || Platform.isLinux || Platform.isWindows) {
+    if (operatingSystemShortcutAvailable) {
       return Shortcuts(shortcuts: _webShortcuts, child: child);
     }
 


### PR DESCRIPTION
Currently pubdev says that the widget is not web compatible. This happens because there is an IO import being performed all the time. 

The proposed change is to create a get that is in charge of telling if the operating system has shortcuts or not. Always import the web one that only has foundation and in case the compilation library is an IO one, export the get that has IO with the platform.

Actually it works in the web version even with the import because the check if is web happens first.

I think with this small change pubdev should detect it correctly and it helps to understand the reason for the if. If this is not the case you could implement an abstract class and implement it for each type of library whether it is html or io.
