### PR TITLE
refactor: Initialize MultiSelectController only if not already initialized

### DIFF
--- a/lib/src/controllers/multiselect_controller.dart
+++ b/lib/src/controllers/multiselect_controller.dart
@@ -2,6 +2,14 @@ part of '../multi_dropdown.dart';
 
 /// Controller for the multiselect dropdown.
 class MultiSelectController<T> extends ChangeNotifier {
+  /// a flag to indicate whether the controller is initialized.
+  bool _initialized = false;
+
+  /// set initialized flag to true.
+  void _initialize() {
+    _initialized = true;
+  }
+
   List<DropdownItem<T>> _items = [];
 
   List<DropdownItem<T>> _filteredItems = [];

--- a/lib/src/multi_dropdown.dart
+++ b/lib/src/multi_dropdown.dart
@@ -234,7 +234,7 @@ class _MultiDropdownState<T extends Object> extends State<MultiDropdown<T>> {
 
   final OverlayPortalController _portalController = OverlayPortalController();
 
-  late final MultiSelectController<T> _dropdownController =
+  late MultiSelectController<T> _dropdownController =
       widget.controller ?? MultiSelectController<T>();
   final _FutureController _loadingController = _FutureController();
 
@@ -264,9 +264,14 @@ class _MultiDropdownState<T extends Object> extends State<MultiDropdown<T>> {
       unawaited(_handleFuture());
     }
 
+    if (!_dropdownController._initialized) {
+      _dropdownController
+        .._initialize()
+        ..setItems(widget.items);
+    }
+
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _dropdownController
-        ..setItems(widget.items)
         ..addListener(_controllerListener)
         .._setOnSelectionChange(widget.onSelectionChange)
         .._setOnSearchChange(widget.onSearchChange);
@@ -341,6 +346,8 @@ class _MultiDropdownState<T extends Object> extends State<MultiDropdown<T>> {
       _dropdownController
         ..removeListener(_controllerListener)
         ..dispose();
+
+      _dropdownController = widget.controller ?? MultiSelectController<T>();
 
       _initializeController();
     }


### PR DESCRIPTION
When the dropdown is used within a ListView, it gets rebuilt during scrolling, causing the widget to reset. To address this, I've added an initialization check in the initState method to verify if the controller has already been initialized. This prevents the widget from resetting during the scroll, effectively solving the issue.

- [x] Dropdown reset issue on scroll.