### PR TITLE
fix: Prevent interaction with disabled dropdown options and adjust chip delete icon color

### DIFF
--- a/lib/src/multi_dropdown.dart
+++ b/lib/src/multi_dropdown.dart
@@ -650,7 +650,8 @@ class _MultiDropdownState<T extends Object> extends State<MultiDropdown<T>> {
                   Icon(
                     Icons.close,
                     size: 16,
-                    color: widget.enabled ? null : Colors.grey,
+                    color:
+                        widget.enabled ? null : Theme.of(context).disabledColor,
                   ),
             ),
           ),

--- a/lib/src/multi_dropdown.dart
+++ b/lib/src/multi_dropdown.dart
@@ -638,6 +638,8 @@ class _MultiDropdownState<T extends Object> extends State<MultiDropdown<T>> {
           const SizedBox(width: 4),
           InkWell(
             onTap: () {
+              if (!widget.enabled) return;
+
               _dropdownController
                   .unselectWhere((element) => element.label == option.label);
             },
@@ -645,7 +647,11 @@ class _MultiDropdownState<T extends Object> extends State<MultiDropdown<T>> {
               width: 16,
               height: 16,
               child: chipDecoration.deleteIcon ??
-                  const Icon(Icons.close, size: 16),
+                  Icon(
+                    Icons.close,
+                    size: 16,
+                    color: widget.enabled ? null : Colors.grey,
+                  ),
             ),
           ),
         ],


### PR DESCRIPTION
- [x] Selected items can no longer be removed when the dropdown is disabled.