### PR TITLE
fix: fix text overflow issue when label content is too long

### DIFF
--- a/lib/src/multi_dropdown.dart
+++ b/lib/src/multi_dropdown.dart
@@ -634,7 +634,9 @@ class _MultiDropdownState<T extends Object> extends State<MultiDropdown<T>> {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Text(option.label, style: chipDecoration.labelStyle),
+          Flexible(
+            child: Text(option.label, style: chipDecoration.labelStyle),
+          ),
           const SizedBox(width: 4),
           InkWell(
             onTap: () {


### PR DESCRIPTION
Ensure that labels automatically break lines properly to avoid overflow when the text is too lengthy


before | after
 ---- | ----
![Screenshot_20250111_185140](https://github.com/user-attachments/assets/f556c6eb-1aae-4bed-8c6f-d5f3a8383d75) | ![Screenshot_20250111_185714](https://github.com/user-attachments/assets/bba769a6-c077-4363-93a5-55ef5f6e0132)