### PR TITLE
Add ability to pass in a TextStyle for the dropdown item

### DIFF
--- a/lib/src/models/decoration.dart
+++ b/lib/src/models/decoration.dart
@@ -51,6 +51,8 @@ class DropdownItemDecoration {
   ///
   /// [textColor] is the text color of the dropdown item. The default value is black.
   ///
+  ///  [textStyle] is the textSTyle of the dropdown item.  The default value is none.
+  ///
   /// [disabledTextColor] is the text color of the disabled dropdown item. The default value is black.
   ///
   /// [selectedIcon] is the icon to display for the selected dropdown item. The default value is Icon(Icons.check).
@@ -62,6 +64,7 @@ class DropdownItemDecoration {
     this.selectedBackgroundColor,
     this.selectedTextColor,
     this.textColor,
+    this.textStyle,
     this.disabledTextColor,
     this.selectedIcon = const Icon(Icons.check),
     this.disabledIcon,
@@ -81,6 +84,9 @@ class DropdownItemDecoration {
 
   /// The text color of the dropdown item.
   final Color? textColor;
+
+  /// The textSTyle to apply to the dropdown item.
+  final TextStyle? textStyle;
 
   /// The text color of the disabled dropdown item.
   final Color? disabledTextColor;

--- a/lib/src/models/decoration.dart
+++ b/lib/src/models/decoration.dart
@@ -51,7 +51,7 @@ class DropdownItemDecoration {
   ///
   /// [textColor] is the text color of the dropdown item. The default value is black.
   ///
-  ///  [textStyle] is the textSTyle of the dropdown item.  The default value is none.
+  /// [textStyle] is the textSTyle of the dropdown item.  The default value is none.
   ///
   /// [disabledTextColor] is the text color of the disabled dropdown item. The default value is black.
   ///
@@ -85,7 +85,7 @@ class DropdownItemDecoration {
   /// The text color of the dropdown item.
   final Color? textColor;
 
-  /// The textSTyle to apply to the dropdown item.
+  /// The text style to apply to the dropdown item.
   final TextStyle? textStyle;
 
   /// The text color of the disabled dropdown item.

--- a/lib/src/widgets/dropdown.dart
+++ b/lib/src/widgets/dropdown.dart
@@ -157,7 +157,10 @@ class _Dropdown<T> extends StatelessWidget {
 
     return Ink(
       child: ListTile(
-        title: Text(option.label),
+        title: Text(
+          option.label,
+          style: dropdownItemDecoration.textStyle ?? const TextStyle(),
+        ),
         trailing: trailing,
         dense: true,
         autofocus: true,


### PR DESCRIPTION
overriding the entire ListTile functionality was too hard to do, so I ended up forking this and adding my own option to pass in a textStyle to control the look of the dropdown items, as the default font size was too small.  This lets you pass in an entire textStyle, so you can control weight, size, family, etc.

Before:
![image](https://github.com/user-attachments/assets/45502874-2ea4-4824-926f-dd9ac54d31d4)

After:
```
 DropdownItemDecoration(
    textStyle: TextStyle(fontSize: 20),
...
```
![image](https://github.com/user-attachments/assets/82a60080-a024-4c12-92a3-cfe68a026c34)
