### PR TITLE
fix: analysis_options excludes for Flutter 3.47 CI dry-run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 - **Field InkWell Material ancestor**: Wrap the field `InkWell` in `Material(type: MaterialType.transparency)` so the dropdown no longer crashes with "No Material widget found" on Flutter 3.47+ (#223, #224)
+- **CI publish dry-run**: Commit Flutter 3.47 `analysis_options.yaml` excludes so `flutter pub get` no longer dirties the tree and fails dry-run validation
 
 ## 3.2.1
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,15 @@
 include: package:very_good_analysis/analysis_options.yaml
 
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
+
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options
 

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -9,6 +9,16 @@
 # packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
+
 linter:
   # The lint rules applied to this project can be customized in the
   # section below to disable rules from the `package:flutter_lints/flutter.yaml`


### PR DESCRIPTION
## Summary
- Commit Flutter 3.47 `analysis_options.yaml` excludes (`build/**`, platform dirs) for the package and example
- Prevents `flutter pub get` from dirtying git, which was failing the Publish Dry Run job after #222

## Test plan
- [ ] CI Analyze / Test / Publish Dry Run all green on merge to main


Made with [Cursor](https://cursor.com)